### PR TITLE
Deprecation notice: SCMS files now included in ACM project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# ⚠️ DEPRECATION NOTICE
+This repository is no longer needed, as the SCMS files are now included directly in the [asn1_codec](https://www.github.com/usdot-jpo-ode/asn1_codec) project. It is considered deprecated and may be archived or removed soon.
+
+---
+
 # scms-asn1
 
 This repository contains the ASN.1 definitions for data containers and protocols


### PR DESCRIPTION
# PR Details
## Description
### Problem
The scms-asn1 repository is no longer necessary, as its contents (SCMS files) are now integrated directly into the ACM project. Without clear communication, users may continue to use or contribute to this deprecated repository unnecessarily.

### Solution
Added a deprecation notice at the top of the README.md to inform users that this repository is deprecated and may be archived or removed soon.

## Related GitHub Issue
N/A

## Related Jira Key
N/A

## Motivation and Context
Since the SCMS files are integrated directly in the ACM project, this repo is no longer needed.

## How Has This Been Tested?
Documentation change, no testing necessary.

## Types of changes
- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)
- [x] Documentation

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
